### PR TITLE
[fix] update Solidity version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Updated BoringVault contracts to use solidity version ^0.8.21
+
 ```
  .-. .-..-. .-.  ,--,  ,-.    ,---.  .-. .-.   .---.
  |  \| || | | |.' .')  | |    | .-'  | | | |  ( .-._)

--- a/src/atomic-queue/AtomicQueue.sol
+++ b/src/atomic-queue/AtomicQueue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { FixedPointMathLib } from "@solmate/utils/FixedPointMathLib.sol";
 import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";

--- a/src/base/BoringVault.sol
+++ b/src/base/BoringVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { ERC721Holder } from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";

--- a/src/base/Roles/AccountantWithRateProviders.sol
+++ b/src/base/Roles/AccountantWithRateProviders.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { FixedPointMathLib } from "@solmate/utils/FixedPointMathLib.sol";
 import { IRateProvider } from "src/interfaces/IRateProvider.sol";

--- a/src/base/Roles/CrossChain/CrossChainOPTellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/CrossChain/CrossChainOPTellerWithMultiAssetSupport.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { CrossChainTellerBase, BridgeData, ERC20 } from "./CrossChainTellerBase.sol";
 

--- a/src/base/Roles/CrossChain/CrossChainTellerBase.sol
+++ b/src/base/Roles/CrossChain/CrossChainTellerBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { TellerWithMultiAssetSupport } from "../TellerWithMultiAssetSupport.sol";
 import { ERC20 } from "@solmate/tokens/ERC20.sol";

--- a/src/base/Roles/CrossChain/MultiChainLayerZeroTellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/CrossChain/MultiChainLayerZeroTellerWithMultiAssetSupport.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { MultiChainTellerBase, MultiChainTellerBase_MessagesNotAllowedFrom } from "./MultiChainTellerBase.sol";
 import { BridgeData, ERC20 } from "./CrossChainTellerBase.sol";

--- a/src/base/Roles/CrossChain/MultiChainTellerBase.sol
+++ b/src/base/Roles/CrossChain/MultiChainTellerBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { CrossChainTellerBase, BridgeData } from "./CrossChainTellerBase.sol";
 

--- a/src/base/Roles/ManagerWithMerkleVerification.sol
+++ b/src/base/Roles/ManagerWithMerkleVerification.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { FixedPointMathLib } from "@solmate/utils/FixedPointMathLib.sol";
 import { BoringVault } from "src/base/BoringVault.sol";

--- a/src/base/Roles/TellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/TellerWithMultiAssetSupport.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { ERC20 } from "@solmate/tokens/ERC20.sol";
 import { WETH } from "@solmate/tokens/WETH.sol";

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { BoringVault, ERC20 } from "src/base/BoringVault.sol";
 import { TellerWithMultiAssetSupport } from "src/base/Roles/TellerWithMultiAssetSupport.sol";

--- a/src/interfaces/BeforeTransferHook.sol
+++ b/src/interfaces/BeforeTransferHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 interface BeforeTransferHook {
     function beforeTransfer(address from) external view;


### PR DESCRIPTION
Previously Solidity version was pinned to 0.8.21, but Plume contracts require ^0.8.25. 
Changed version constraint from `0.8.21` to `^0.8.21` to allow compatibility with newer versions.